### PR TITLE
added a recipe to disable server side caching

### DIFF
--- a/recipes/disable_cache.rb
+++ b/recipes/disable_cache.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook:: iis-lb
+# Recipe:: disable_cache.rb
+#
+# Copyright:: 2017, The Authors, All Rights Reserved.
+
+powershell_script 'myServerFarm_disable_disk_cache' do
+  code <<-EOH
+    $filter = "/webFarms/webFarm[@name='myServerFarm']/applicationRequestRouting/protocol/cache"
+    $path = 'MACHINE/WEBROOT/APPHOST'
+    Set-WebConfigurationProperty -PSPath $path -Filter $filter -Name 'enabled' -Value 'False'
+  EOH
+end
+
+powershell_script 'myServerFarm_set_cache_interval' do
+  code <<-EOH
+    $filter = "/webFarms/webFarm[@name='myServerFarm']/applicationRequestRouting/protocol/cache"
+    $path = 'MACHINE/WEBROOT/APPHOST'
+    Set-WebConfigurationProperty -PSPath $path -Filter $filter -Name 'validationInterval' -Value '00:00:00'
+  EOH
+end

--- a/spec/unit/recipes/disable_cache_spec.rb
+++ b/spec/unit/recipes/disable_cache_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook:: iis-lb
+# Spec:: default
+#
+# Copyright:: 2017, The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'iis-lb::disable_cache.rb' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/test/smoke/default/disable_cache.rb
+++ b/test/smoke/default/disable_cache.rb
@@ -1,0 +1,18 @@
+# # encoding: utf-8
+
+# Inspec test for recipe iis-lb::disable_cache.rb
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
+  end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
+end


### PR DESCRIPTION
IIS Server has 60 second server side cache turned on by default. To switch this off you need to
1. Start menu > Administrative Tools > Internet Information Services (IIS) Manager.
2. Expand your node on left side > Server Farms > myServerFarm
3. Double click 'caching', and set to '0'
4. Close & save

This recipe uses powershell to do this.  This would be a useful addition to the cookbook - in Chef Essentials Windows class I've had to get folks to switch caching off to see load balancing work.